### PR TITLE
Not related to kuboom

### DIFF
--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -10,4 +10,12 @@ export default client.on("messageCreate", async (message) => {
 
         message.delete();
     }
+
+    // kuboom related
+    else if (message.content.toLowerCase().includes("kuboom")) {
+        let substrIdx = message.content.indexOf("kuboom")
+        if (message.content.toLowerCase()[substrIdx - 1] != '!') {
+            message.reply("hey! we're the **kaboom.js** game engine discord server, not the _kuboom_ discord server...")
+        }
+    }
 });


### PR DESCRIPTION
Added so that when someone mentions kuboom (if the substring contains '!' that means that the user (kaboom users) know they're just mentioning kuboom and not actually talking or asking about it) the bot replies saying that we're not related to kuboom, inmediate response